### PR TITLE
fix broken regex for id containing the "s" character

### DIFF
--- a/src/hiccups/runtime.cljs
+++ b/src/hiccups/runtime.cljs
@@ -2,7 +2,7 @@
   (:require [clojure.string :as cstring]))
 
 (def ^{:doc "Regular expression that parses a CSS-style id and class from a tag name." :private true}
-  re-tag #"([^\s\.#]+)(?:#([^s\.#]+))?(?:\.([^\s#]+))?")
+  re-tag #"([^\s\.#]+)(?:#([^\s\.#]+))?(?:\.([^\s#]+))?")
 
 (def ^{:doc "Characters to replace when escaping HTML" :private true}
   character-escapes {\& "&amp;", \< "&lt;", \> "&gt;", \" "&quot;"})
@@ -17,7 +17,7 @@
   (if (or (keyword? x) (symbol? x))
     (name x)
     (str x)))
-  
+
 (def ^:dynamic *html-mode* :xml)
 
 (defn- xml-mode? []
@@ -56,7 +56,7 @@
   (apply str
     (sort (map render-attribute attrs))))
 
-(defn normalize-element 
+(defn normalize-element
   "Ensure a tag vector is of the form [tag-name attrs content]."
   [[tag & content]]
   (when (not (or (keyword? tag) (symbol? tag) (string? tag)))


### PR DESCRIPTION
Hello, 

This fixes element id parsing when they contain an "s": 

```
(hiccups/html [:div#search-form]))
```

the following would return an empty root tag with no name and attributes/id, this is caused by a missing escaping \ in the regex

You can test the issue with the following in a js console: 

> 'div#search-form'.match(/([^\s.#]+)(?:#([^s.#]+))?(?:.([^\s#]+))?/) 
> ["div", "div", undefined, undefined]
> 
> 'div#search-form'.match(/([^\s.#]+)(?:#([^\s.#]+))?(?:.([^\s#]+))?/)
> ["div#search-form", "div", "search-form", undefined]
