### PR TITLE
Fix for bug #4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject hiccups "0.2.0"
+(defproject hiccups "0.3.0-SNAPSHOT"
   :description "A ClojureScript port of Hiccup - a fast library for rendering HTML in ClojureScript"
   :url "http://github.com/teropa/hiccups"
   :dependencies [[org.clojure/clojure "1.4.0"]]

--- a/src/hiccups/runtime.cljs
+++ b/src/hiccups/runtime.cljs
@@ -63,7 +63,7 @@
     (throw (str tag " is not a valid tag name")))
   (let [[_ tag id class] (re-matches re-tag (as-str tag))
         tag-attrs        {:id id
-                          :class (if class (.replace ^String class "." " "))}
+                          :class (if class (cstring/replace class "." " "))}
         map-attrs        (first content)]
     (if (map? map-attrs)
       [tag (merge tag-attrs map-attrs) (next content)]


### PR DESCRIPTION
In javascript, `"class1.class2.class3".replace(".", " ")` will only replace the first dot. `clojure.string/replace` works as expected.
